### PR TITLE
feat: add optional undetected chrome driver

### DIFF
--- a/env_example.txt
+++ b/env_example.txt
@@ -48,6 +48,7 @@ MAX_LOGIN_ATTEMPTS=3
 LOGIN_WAIT_TIME=5
 CAPTCHA_WAIT_TIME=10
 DEBUG_MODE=false
+USE_UNDETECTED_CHROME=false
 
 # Database Type (currently only MySQL supported)
-DB_TYPE=mysql 
+DB_TYPE=mysql

--- a/project_config.py
+++ b/project_config.py
@@ -62,6 +62,7 @@ class Config:
         # Browser & Session Configurations
         self.CHROME_PROFILE_PATH = self.get_env("CHROME_PROFILE_PATH", os.path.join(os.getcwd(), "chrome_profile"))
         self.COOKIE_STORAGE_PATH = self.get_env("COOKIE_STORAGE_PATH", os.path.join(os.getcwd(), "cookies"))
+        self.USE_UNDETECTED_CHROME = self.get_env("USE_UNDETECTED_CHROME", "false").lower() == "true"
 
         # Security & Session Settings
         self.MAX_LOGIN_ATTEMPTS = self.get_env("MAX_LOGIN_ATTEMPTS", 3, cast_type=int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ dataclasses
 PyQt6
 schedule
 pydantic
+undetected-chromedriver

--- a/social_media_automation.py
+++ b/social_media_automation.py
@@ -98,8 +98,10 @@ class SocialMediaAutomation:
     
     def initialize_driver(self):
         """Initialize the web driver."""
-        self.driver = get_driver()
-        logger.info("✅ Web driver initialized")
+        self.driver = get_driver(use_undetected=config.USE_UNDETECTED_CHROME)
+        logger.info(
+            "✅ Web driver initialized (undetected=%s)", config.USE_UNDETECTED_CHROME
+        )
     
     def close_driver(self):
         """Close the web driver."""


### PR DESCRIPTION
## Summary
- add undetected-chromedriver fallback and optional flag in login manager
- expose USE_UNDETECTED_CHROME config/env and log in automation initializer
- document new setting and dependency in env example and requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'setup_logging')*


------
https://chatgpt.com/codex/tasks/task_e_688ca0510f9083299bf8b8a5bd77080c